### PR TITLE
Try to get build URL one more time if unable to read json

### DIFF
--- a/zk-test-report/zk_test_analyzer.py
+++ b/zk-test-report/zk_test_analyzer.py
@@ -164,10 +164,11 @@ def analyze_build(args):
         excludes = url_max_build["excludes"]
 
         try:
+            raise ValueError("hello world")
             json_response = requests.get(url + "/api/json").json()      
-        except ValueError:
+        except ValueError as e:
             # Try it one more time in case Jenkins had some intermittent failure
-            LOG.error("failed to get: " + url + "/api/json, re-trying...")
+            LOG.error("Retrying to get: " + url + "/api/json : " + str(e))
             json_response = requests.get(url + "/api/json").json()      
 
         if json_response.has_key("builds"):

--- a/zk-test-report/zk_test_analyzer.py
+++ b/zk-test-report/zk_test_analyzer.py
@@ -162,7 +162,14 @@ def analyze_build(args):
     for url_max_build in expanded_urls:
         url = url_max_build["url"]
         excludes = url_max_build["excludes"]
-        json_response = requests.get(url + "/api/json").json()
+
+        try:
+            json_response = requests.get(url + "/api/json").json()      
+        except ValueError:
+            # Try it one more time in case Jenkins had some intermittent failure
+            LOG.error("failed to get: " + url + "/api/json, re-trying...")
+            json_response = requests.get(url + "/api/json").json()      
+
         if json_response.has_key("builds"):
             builds = json_response["builds"]
             LOG.info("Analyzing job: %s", url)


### PR DESCRIPTION
Apache Jenkins sometimes returns an error when getting build information and request has to be re-tried.
Added some logic to try to get it one more time if ValueError occured. (unable to read json)